### PR TITLE
Multiuser JupyterHub capability

### DIFF
--- a/emr-nodocker/terraform/emr.tf
+++ b/emr-nodocker/terraform/emr.tf
@@ -32,7 +32,7 @@ resource "aws_emr_cluster" "emr-spark-cluster" {
   bootstrap_action {
     path = "${var.bootstrap_script}"
     name = "geopyspark"
-    args = ["${var.rpm_bucket}", "${var.jupyterhub_oauth_class}", "${var.oauth_client_id}", "${var.oauth_client_secret}"]
+    args = ["${var.rpm_bucket}", "${var.jupyterhub_oauth_module}", "${var.jupyterhub_oauth_class}", "${var.oauth_client_id}", "${var.oauth_client_secret}"]
   }
 }
 

--- a/emr-nodocker/terraform/emr.tf
+++ b/emr-nodocker/terraform/emr.tf
@@ -32,7 +32,7 @@ resource "aws_emr_cluster" "emr-spark-cluster" {
   bootstrap_action {
     path = "${var.bootstrap_script}"
     name = "geopyspark"
-    args = ["${var.rpm_bucket}"]
+    args = ["${var.rpm_bucket}", "${var.jupyterhub_oauth_class}", "${var.oauth_client_id}", "${var.oauth_client_secret}"]
   }
 }
 

--- a/emr-nodocker/terraform/variables.tf
+++ b/emr-nodocker/terraform/variables.tf
@@ -61,6 +61,12 @@ variable "bootstrap_script" {
   description = "Bootstrap Script"
 }
 
+variable "jupyterhub_oauth_module" {
+  type        = "string"
+  description = "Name of the jupyterhub/oauthenticator module to import the jupyterhub_oauth_class from"
+  default     = "github"
+}
+
 variable "jupyterhub_oauth_class" {
   type        = "string"
   description = "Name of the OAuth class provided by jupyterhub/oauthenticator"

--- a/emr-nodocker/terraform/variables.tf
+++ b/emr-nodocker/terraform/variables.tf
@@ -60,3 +60,19 @@ variable "bootstrap_script" {
   type        = "string"
   description = "Bootstrap Script"
 }
+
+variable "jupyterhub_oauth_class" {
+  type        = "string"
+  description = "Name of the OAuth class provided by jupyterhub/oauthenticator"
+  default     = "LocalGitHubOAuthenticator"
+}
+
+variable "oauth_client_id" {
+  type        = "string"
+  description = "Client ID token for OAuth server"
+}
+
+variable "oauth_client_secret" {
+  type        = "string"
+  description = "Client secret token for OAuth server"
+}


### PR DESCRIPTION
This PR adds the capability to create multiple users in an EMR instance and log in to JupyterHub using those accounts.  This feature has been preliminarily tested, showing that it is possible to create a non-`hadoop` user, log in via that account, and execute spark commands in the notebook.  Further testing/discussion is likely warranted.

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>