### PR TITLE
Separate Installation Of geopyspark(|-netcdf)

### DIFF
--- a/rpms/build/geopyspark.mk
+++ b/rpms/build/geopyspark.mk
@@ -4,11 +4,11 @@ archives/geopyspark-$(GEOPYSPARK_SHA).zip:
 archives/geopyspark-netcdf-$(GEOPYSPARK_NETCDF_SHA).zip:
 	curl -L "https://github.com/geotrellis/geopyspark-netcdf/archive/$(GEOPYSPARK_NETCDF_SHA).zip" -o $@
 
-rpmbuild/SOURCES/geopyspark.tar:
+rpmbuild/SOURCES/geopyspark.tar: geopyspark/requirements1.txt geopyspark/requirements2.txt
 	tar cvf $@ geopyspark/
 
 rpmbuild/RPMS/x86_64/geopyspark-$(GEOPYSPARK_VERSION)-13.x86_64.rpm rpmbuild/RPMS/x86_64/geopyspark-worker-$(GEOPYSPARK_VERSION)-13.x86_64.rpm: rpmbuild/SPECS/geopyspark.spec scripts/geopyspark.sh rpmbuild/SOURCES/geopyspark.tar \
-archives/geopyspark-$(GEOPYSPARK_SHA).zip archives/geopyspark-netcdf-$(GEOPYSPARK_NETCDF_SHA).zip archives/$(GEOPYSPARK_JAR) archives/$(NETCDF_JAR)
+archives/geopyspark-$(GEOPYSPARK_SHA).zip archives/geopyspark-netcdf-$(GEOPYSPARK_NETCDF_SHA).zip
 	cp -f archives/geopyspark-netcdf-$(GEOPYSPARK_NETCDF_SHA).zip archives/geopyspark-netcdf.zip
 	cp -f archives/geopyspark-$(GEOPYSPARK_SHA).zip archives/geopyspark.zip
 	docker run -it --rm \

--- a/rpms/build/geopyspark/requirements1.txt
+++ b/rpms/build/geopyspark/requirements1.txt
@@ -1,5 +1,4 @@
 appdirs==1.4.3
-/archives/geopyspark-netcdf.zip
 /archives/geopyspark.zip
 numpy==1.12.1
 packaging==16.8

--- a/rpms/build/geopyspark/requirements2.txt
+++ b/rpms/build/geopyspark/requirements2.txt
@@ -1,0 +1,1 @@
+/archives/geopyspark-netcdf.zip

--- a/rpms/build/rpmbuild/SPECS/geopyspark.spec
+++ b/rpms/build/rpmbuild/SPECS/geopyspark.spec
@@ -29,7 +29,8 @@ echo
 
 %install
 find /usr/local/lib /usr/local/lib64 | sort > before.txt
-pip3 install -r requirements.txt
+pip3 install -r requirements1.txt
+pip3 install -r requirements2.txt
 find /usr/local/lib /usr/local/lib64 | sort > after.txt
 tar cvf /tmp/packages.tar $(diff before.txt after.txt | grep '^>' | cut -f2 '-d ')
 cd %{buildroot}


### PR DESCRIPTION
Installing them together can be problematic because `geopyspark-netcdf` depends on `geopyspark`, which might result in a different version of the latter being installed than expected.

@jbouffard 