### PR TITLE
Add EMR cluster configurations.json

### DIFF
--- a/terraform-nodocker/cluster-configurations.json
+++ b/terraform-nodocker/cluster-configurations.json
@@ -1,0 +1,31 @@
+[
+    {
+        "Classification": "spark",
+        "Properties": {
+            "maximizeResourceAllocation": "true"
+        }
+    },
+    {
+        "Classification": "spark-defaults",
+        "Properties": {
+            "spark.driver.maxResultSize": "3G",
+            "spark.dynamicAllocation.enabled": "true",
+            "spark.shuffle.service.enabled": "true",
+            "spark.shuffle.compress": "true",
+            "spark.shuffle.spill.compress": "true",
+            "spark.rdd.compress": "true",
+            "spark.yarn.executor.memoryOverhead": "1G",
+            "spark.yarn.driver.memoryOverhead": "1G",
+            "spark.driver.maxResultSize": "3G",
+            "spark.executor.extraJavaOptions" : "-XX:+UseParallelGC -Dgeotrellis.s3.threads.rdd.write=64"
+        }
+    },
+    {
+        "Classification": "yarn-site",
+        "Properties": {
+            "yarn.resourcemanager.am.max-attempts": "1",
+            "yarn.nodemanager.vmem-check-enabled": "false",
+            "yarn.nodemanager.pmem-check-enabled": "false"
+        }
+    }
+]

--- a/terraform-nodocker/emr.tf
+++ b/terraform-nodocker/emr.tf
@@ -42,6 +42,8 @@ resource "aws_emr_cluster" "emr-spark-cluster" {
     ]
   }
 
+  configurations = "cluster-configurations.json"
+
   depends_on = ["aws_s3_bucket_object.bootstrap"]
 }
 


### PR DESCRIPTION
Primarily this:
- Disable YARN memory limit checking
- Enables Spark maximizeResourceAllocation
- Enables YARN Spark shuffle service
- Enables dynamic allocation

These configurations were iterated on https://github.com/geotrellis/geotrellis-friction-surface where they produced good results for batch jobs. Similarly they appear to produce good resource for interactive workbook.

Possibly they have implications for cluster multi-tenancy but that concern is not in current use cases.