### PR TITLE
Use EMR version 5.13.0

### DIFF
--- a/terraform/bootstrap.sh
+++ b/terraform/bootstrap.sh
@@ -145,7 +145,7 @@ EOF
         "PYSPARK_PYTHON": "/usr/bin/python3.4",
         "PYSPARK_DRIVER_PYTHON": "/usr/bin/python3.4",
         "SPARK_HOME": "/usr/lib/spark",
-        "PYTHONPATH": "/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.4-src.zip",
+        "PYTHONPATH": "/usr/lib/spark/python/lib/pyspark.zip:/usr/lib/spark/python/lib/py4j-0.10.6-src.zip",
         "GEOPYSPARK_JARS_PATH": "/opt/jars",
         "YARN_CONF_DIR": "/etc/hadoop/conf",
         "PYSPARK_SUBMIT_ARGS": "--conf hadoop.yarn.timeline-service.enabled=false pyspark-shell"

--- a/terraform/emr.tf
+++ b/terraform/emr.tf
@@ -2,7 +2,7 @@ resource "aws_emr_cluster" "emr-spark-cluster" {
   name          = "GeoPySpark Cluster"
   applications  = ["Hadoop", "Spark", "Ganglia"]
   log_uri       = "${var.s3_log_uri}"
-  release_label = "emr-5.7.0"
+  release_label = "emr-5.13.0"
   service_role  = "${var.emr_service_role}"
 
   ec2_attributes {


### PR DESCRIPTION
Brings in Spark 2.3.0 which is used by GeoTrellis 2.0
